### PR TITLE
Fix haproxy on mac, clean up mac artifact, ...

### DIFF
--- a/ci/macos.10.12.sh
+++ b/ci/macos.10.12.sh
@@ -63,6 +63,5 @@ mkdir -p $RELEASE_NAME
 cp -Rp lethean-wallet-gui.app $RELEASE_NAME/
 cp ../../../ci/package-artifacts/CHANGELOG.txt $RELEASE_NAME/
 cp ../../../ci/package-artifacts/README.txt $RELEASE_NAME/
-cp ../../../ci/package-artifacts/*.http $RELEASE_NAME/
 tar -cvjf $RELEASE_NAME.tar.bz2 $RELEASE_NAME
 shasum -a 256 $RELEASE_NAME.tar.bz2 > $RELEASE_NAME.tar.bz2.sha256.txt

--- a/ci/macos.10.13.sh
+++ b/ci/macos.10.13.sh
@@ -63,6 +63,5 @@ mkdir -p $RELEASE_NAME
 cp -Rp lethean-wallet-gui.app $RELEASE_NAME/
 cp ../../../ci/package-artifacts/CHANGELOG.txt $RELEASE_NAME/
 cp ../../../ci/package-artifacts/README.txt $RELEASE_NAME/
-cp ../../../ci/package-artifacts/*.http $RELEASE_NAME/
 tar -cvjf $RELEASE_NAME.tar.bz2 $RELEASE_NAME
 shasum -a 256 $RELEASE_NAME.tar.bz2 > $RELEASE_NAME.tar.bz2.sha256.txt

--- a/pages/Intense.qml
+++ b/pages/Intense.qml
@@ -1016,11 +1016,15 @@ Rectangle {
                                 // check the unlocked balance to lock the connect button.
                                 // unlockedbalance == true because its have to run only once
                                 if(walletManager.displayAmount(currentWallet.unlockedBalance) < 1) {
+                                    statusText.text = qsTr("Waiting for wallet balance");
                                     timerUnlockedBalance.start();
                                     unlockedBalance = false
                                     this.enabled = false
                                 }
                                 else{
+                                    if (statusText.text === qsTr("Waiting for wallet balance")) {
+                                      statusText.text = "";
+                                    }
                                     timerUnlockedBalance.stop();
                                     unlockedBalance = true
                                     this.enabled = true

--- a/pages/IntenseDashboard.qml
+++ b/pages/IntenseDashboard.qml
@@ -234,7 +234,7 @@ Rectangle {
 
     function showProxyStartupError() {
         errorPopup.title = "Proxy Startup Error";
-        errorPopup.content = "There was an error trying to start the proxy service.\nIf the problem persists, please contact support.\n Wallet path: "  + getPathToSaveHaproxyConfig(persistentSettings.wallet_path) + "\nPlease confirm that you have HAProxy installed in your machine.";
+        errorPopup.content = "There was an error trying to start the proxy service.\n" + callhaproxy.haproxyStatus + ".\n Wallet path: "  + getPathToSaveHaproxyConfig(persistentSettings.wallet_path) + "\nPlease confirm that you have HAProxy installed in your machine.";
         errorPopup.open();
 
         // set this to 1 so the popup waiting for payment is not shown

--- a/pages/IntenseDashboard.qml
+++ b/pages/IntenseDashboard.qml
@@ -88,13 +88,8 @@ Rectangle {
         return path[0]+"/";
     }
 
-    function refreshHaProxyPath() {
-        pathToSaveHaproxyConfig = (typeof currentWallet == "undefined") ? persistentSettings.wallet_path : currentWallet.walletLogPath;
-    }
-
     function setPayment(){
 
-        refreshHaProxyPath();
         var walletHaproxyPath = getPathToSaveHaproxyConfig(pathToSaveHaproxyConfig);
 
         var data = new Date();
@@ -386,7 +381,6 @@ Rectangle {
                 transferredTextLine.text = "Proxy not running!"
                 transferredTextLine.color = "#FF4500"
                 transferredTextLine.font.bold = true
-                refreshHaProxyPath();
                 var walletHaproxyPath = getPathToSaveHaproxyConfig(pathToSaveHaproxyConfig);
                 callhaproxy.haproxyCert( walletHaproxyPath, certArray );
 
@@ -2115,7 +2109,6 @@ Rectangle {
 
                 console.log( "Generating certificate" );
 
-                refreshHaProxyPath();
                 var walletHaproxyPath = getPathToSaveHaproxyConfig(pathToSaveHaproxyConfig);
 
                 callhaproxy.haproxyCert( walletHaproxyPath, certArray );

--- a/pages/IntenseDashboard.qml
+++ b/pages/IntenseDashboard.qml
@@ -53,7 +53,11 @@ Rectangle {
     // keep track haproxy verify 10 before payment and 300 after payment
     property int verification: 10
 
+#if defined(Q_OS_MAC)
+    property string pathToSaveHaproxyConfig: (typeof currentWallet == "undefined") ? persistentSettings.wallet_path : currentWallet.daemonLogPath
+#else
     property string pathToSaveHaproxyConfig: (typeof currentWallet == "undefined") ? persistentSettings.wallet_path : currentWallet.walletLogPath
+#endif
 
     function getITNS() {
         itnsStart = itnsStart + ( parseFloat(cost) / firstPrePaidMinutes * subsequentPrePaidMinutes );

--- a/pages/IntenseDashboard.qml
+++ b/pages/IntenseDashboard.qml
@@ -53,11 +53,7 @@ Rectangle {
     // keep track haproxy verify 10 before payment and 300 after payment
     property int verification: 10
 
-#if defined(Q_OS_MAC)
-    property string pathToSaveHaproxyConfig: (typeof currentWallet == "undefined") ? persistentSettings.wallet_path : currentWallet.daemonLogPath
-#else
-    property string pathToSaveHaproxyConfig: (typeof currentWallet == "undefined") ? persistentSettings.wallet_path : currentWallet.walletLogPath
-#endif
+    property string pathToSaveHaproxyConfig: (typeof currentWallet == "undefined") ? persistentSettings.wallet_path : (Qt.platform.os === "osx" ? currentWallet.daemonLogPath : currentWallet.walletLogPath)
 
     function getITNS() {
         itnsStart = itnsStart + ( parseFloat(cost) / firstPrePaidMinutes * subsequentPrePaidMinutes );

--- a/pages/IntenseDashboard.qml
+++ b/pages/IntenseDashboard.qml
@@ -88,8 +88,13 @@ Rectangle {
         return path[0]+"/";
     }
 
+    function refreshHaProxyPath() {
+        pathToSaveHaproxyConfig = (typeof currentWallet == "undefined") ? persistentSettings.wallet_path : currentWallet.walletLogPath;
+    }
+
     function setPayment(){
 
+        refreshHaProxyPath();
         var walletHaproxyPath = getPathToSaveHaproxyConfig(pathToSaveHaproxyConfig);
 
         var data = new Date();
@@ -381,6 +386,7 @@ Rectangle {
                 transferredTextLine.text = "Proxy not running!"
                 transferredTextLine.color = "#FF4500"
                 transferredTextLine.font.bold = true
+                refreshHaProxyPath();
                 var walletHaproxyPath = getPathToSaveHaproxyConfig(pathToSaveHaproxyConfig);
                 callhaproxy.haproxyCert( walletHaproxyPath, certArray );
 
@@ -2109,6 +2115,7 @@ Rectangle {
 
                 console.log( "Generating certificate" );
 
+                refreshHaProxyPath();
                 var walletHaproxyPath = getPathToSaveHaproxyConfig(pathToSaveHaproxyConfig);
 
                 callhaproxy.haproxyCert( walletHaproxyPath, certArray );

--- a/src/libwalletqt/Haproxy.cpp
+++ b/src/libwalletqt/Haproxy.cpp
@@ -399,7 +399,7 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
 
     }
     else {
-        m_haproxyStatus = "Failed to open (" + file.error() + ") " + sibling_file_path + "haproxy.cfg";
+        m_haproxyStatus = "Failed to open (" + QString::number(file.error()) + ") " + sibling_file_path + "haproxy.cfg";
         qDebug() << "could not open the file";
         return false;
     }

--- a/src/libwalletqt/Haproxy.cpp
+++ b/src/libwalletqt/Haproxy.cpp
@@ -332,7 +332,12 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
         QString command = "";
         #ifdef Q_OS_WIN
             command = "haproxy.exe -f haproxy.cfg";
-            WinExec(qPrintable(command),SW_HIDE);
+            uint result = WinExec(qPrintable(command),SW_HIDE);            
+            if (result < 31) {
+                m_haproxyStatus = "Failed to launch haproxy (" + QString::number(result) + ") ";
+                qDebug() << "Failed to launch haproxy (Windows): " + QString::number(result);
+                return false;
+            }
         #else
             QString haProxyPath = NULL;
             QString hasHaproxyExecutable = NULL;

--- a/src/libwalletqt/Haproxy.cpp
+++ b/src/libwalletqt/Haproxy.cpp
@@ -340,6 +340,7 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
             #if defined(Q_OS_MAC)
                 // verify if the haproxy exist in Mac if not send an alert
                 QFileInfo check_haproxy_exist_osx("/usr/local/bin/haproxy");
+                check_haproxy_exist_osx.refresh();
                 if (check_haproxy_exist_osx.exists()) {
                     haProxyPath = "/usr/local/bin/haproxy";
                 } else {

--- a/src/libwalletqt/Haproxy.cpp
+++ b/src/libwalletqt/Haproxy.cpp
@@ -343,6 +343,7 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
                 if (check_haproxy_exist_osx.exists()) {
                     haProxyPath = "/usr/local/bin/haproxy";
                 } else {
+                    m_haproxyStatus = "Failed: " + haProxyPath;
                     return false;
                 }
             #else
@@ -384,6 +385,7 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
             // ha proxy location not found if output from command is empty or just the first word from whereis
             if (haProxyPath.isEmpty() || haProxyPath == "haproxy:") {
                 qDebug() << "HAProxy not found!";
+                 m_haproxyStatus = "NotFound: " + haProxyPath;
                 return false;
             }
 
@@ -396,6 +398,7 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
 
     }
     else {
+         m_haproxyStatus = "Failed to open haproxy";
         qDebug() << "could not open the file";
         return false;
     }

--- a/src/libwalletqt/Haproxy.cpp
+++ b/src/libwalletqt/Haproxy.cpp
@@ -397,7 +397,12 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
 
             //system("trap 'pkill -f haproxy; echo teste haproxy; exit;' INT TERM");
             command = haProxyPath + " -f " + sibling_file_path + "haproxy.cfg";
-            system(qPrintable(command));
+            int result = system(qPrintable(command));
+            qDebug() << "Launched haproxy " << QString::number(result);
+            if (result != 0) {
+                m_haproxyStatus = "Failed to launch haproxy (" + QString::number(result) + ") " + haProxyPath + " " + sibling_file_path + "haproxy.cfg";
+                return false;
+            }
         #endif
 
         qDebug() << "Starting Haproxy: " << command;

--- a/src/libwalletqt/Haproxy.cpp
+++ b/src/libwalletqt/Haproxy.cpp
@@ -399,7 +399,7 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
 
     }
     else {
-         m_haproxyStatus = "Failed to open haproxy";
+         m_haproxyStatus = "Failed to open " + sibling_file_path + "haproxy.cfg";
         qDebug() << "could not open the file";
         return false;
     }

--- a/src/libwalletqt/Haproxy.cpp
+++ b/src/libwalletqt/Haproxy.cpp
@@ -399,7 +399,7 @@ bool Haproxy::haproxy(const QString &host, const QString &ip, const QString &por
 
     }
     else {
-         m_haproxyStatus = "Failed to open " + sibling_file_path + "haproxy.cfg";
+        m_haproxyStatus = "Failed to open (" + file.error() + ") " + sibling_file_path + "haproxy.cfg";
         qDebug() << "could not open the file";
         return false;
     }


### PR DESCRIPTION
Improve error handling when haproxy fails to launch or config file cannot be written as expected. 
Parse return value from `WinExec()` or `system()` when launching haproxy.
Added status text indicating when the provider list is awaiting wallet balance before it will permit user interaction with connection buttons.